### PR TITLE
prevent hydroponics input slot extracted by others

### DIFF
--- a/src/main/java/com/misha/blocks/GardenBE.java
+++ b/src/main/java/com/misha/blocks/GardenBE.java
@@ -2,6 +2,7 @@ package com.misha.blocks;
 
 import com.misha.setup.Registration;
 import com.misha.tools.CustomEnergyStorage;
+import com.misha.utils.ExtractLockItemStackHandlerWrapper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -42,9 +43,12 @@ public class GardenBE extends BlockEntity {
 
     //private final TileFluidHandler fluidHandler= createFluid();
     private final ItemStackHandler itemHandler = createHandler();
+
+    private final IItemHandler lockedHandler = new ExtractLockItemStackHandlerWrapper(itemHandler, i -> i == 1);
+
     private final CustomEnergyStorage energyStorage = createEnergy();
     // Never create lazy optionals in getCapability. Always place them as fields in the tile entity:
-    private final LazyOptional<IItemHandler> handler = LazyOptional.of(() -> itemHandler);
+    private final LazyOptional<IItemHandler> handler = LazyOptional.of(() -> lockedHandler);
     private final LazyOptional<IEnergyStorage> energy = LazyOptional.of(() -> energyStorage);
 
     public int counter = 0;
@@ -269,6 +273,9 @@ public class GardenBE extends BlockEntity {
 
     }
 
+    public IItemHandler getItemHandler(){
+        return this.itemHandler;
+    }
 
     private ItemStackHandler createHandler() {
         return new ItemStackHandler(10) {

--- a/src/main/java/com/misha/blocks/GardenContainer.java
+++ b/src/main/java/com/misha/blocks/GardenContainer.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
-import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
@@ -33,14 +32,11 @@ public class GardenContainer extends AbstractContainerMenu {
         this.playerInventory = new InvWrapper(playerInventory);
 
         if (blockEntity != null) {
-            blockEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
-                addSlot(new SlotItemHandler(h, 0, 44, 25));
-
-                for(int i =0;i<9; i++){
-                    addSlot(new SlotItemHandler(h, i+1, 115+((i%3) *18), 7+((i/3)*18)));
-                }
-
-            });
+            IItemHandler h = blockEntity.getItemHandler();
+            addSlot(new SlotItemHandler(h, 0, 44, 25));
+            for(int i =0;i<9; i++){
+                addSlot(new SlotItemHandler(h, i+1, 115+((i%3) *18), 7+((i/3)*18)));
+            }
         }
         layoutPlayerInventorySlots(8, 70);
         trackPower();

--- a/src/main/java/com/misha/blocks/HydroponicsBE.java
+++ b/src/main/java/com/misha/blocks/HydroponicsBE.java
@@ -2,6 +2,7 @@ package com.misha.blocks;
 
 import com.misha.setup.Registration;
 import com.misha.tools.CustomEnergyStorage;
+import com.misha.utils.ExtractLockItemStackHandlerWrapper;
 import net.minecraft.core.BlockPos;
 import net.minecraft.core.Direction;
 import net.minecraft.nbt.CompoundTag;
@@ -19,7 +20,6 @@ import net.minecraftforge.common.capabilities.Capability;
 import net.minecraftforge.common.util.LazyOptional;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
-import net.minecraftforge.fluids.capability.IFluidHandler;
 import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.ItemStackHandler;
@@ -44,9 +44,12 @@ public class HydroponicsBE extends BlockEntity {
 
 
     private final ItemStackHandler itemHandler = createHandler();
+
+    private final IItemHandler lockedHandler = new ExtractLockItemStackHandlerWrapper(itemHandler, i -> i == 1);
+
     private final CustomEnergyStorage energyStorage = createEnergy();
     // Never create lazy optionals in getCapability. Always place them as fields in the tile entity:
-    private final LazyOptional<IItemHandler> handler = LazyOptional.of(() -> itemHandler);
+    private final LazyOptional<IItemHandler> handler = LazyOptional.of(() -> lockedHandler);
     private final LazyOptional<IEnergyStorage> energy = LazyOptional.of(() -> energyStorage);
 
     public int counter = 0;
@@ -288,6 +291,10 @@ public class HydroponicsBE extends BlockEntity {
         tag.put("energy", energyStorage.serializeNBT());
         tag.putInt("counter", counter);
 
+    }
+
+    public IItemHandler getItemHandler(){
+        return this.itemHandler;
     }
 
 

--- a/src/main/java/com/misha/blocks/HydroponicsContainer.java
+++ b/src/main/java/com/misha/blocks/HydroponicsContainer.java
@@ -13,7 +13,6 @@ import net.minecraft.world.item.ItemStack;
 import net.minecraft.world.level.Level;
 import net.minecraftforge.energy.CapabilityEnergy;
 import net.minecraftforge.energy.IEnergyStorage;
-import net.minecraftforge.items.CapabilityItemHandler;
 import net.minecraftforge.items.IItemHandler;
 import net.minecraftforge.items.SlotItemHandler;
 import net.minecraftforge.items.wrapper.InvWrapper;
@@ -35,13 +34,11 @@ short dat = (short) counter;
         this.playerInventory = new InvWrapper(playerInventory);
 
         if (blockEntity != null) {
-            blockEntity.getCapability(CapabilityItemHandler.ITEM_HANDLER_CAPABILITY).ifPresent(h -> {
-                addSlot(new SlotItemHandler(h, 0, 44, 25));
-                for(int i =0;i<9; i++){
-                    addSlot(new SlotItemHandler(h, i+1, 115+((i%3) *18), 7+((i/3)*18)));
-                }
-
-            });
+            IItemHandler h = blockEntity.getItemHandler();
+            addSlot(new SlotItemHandler(h, 0, 44, 25));
+            for(int i =0;i<9; i++){
+                addSlot(new SlotItemHandler(h, i+1, 115+((i%3) *18), 7+((i/3)*18)));
+            }
         }
         layoutPlayerInventorySlots(8, 70);
         trackPower();

--- a/src/main/java/com/misha/utils/ExtractLockItemStackHandlerWrapper.java
+++ b/src/main/java/com/misha/utils/ExtractLockItemStackHandlerWrapper.java
@@ -1,0 +1,53 @@
+package com.misha.utils;
+
+import net.minecraft.world.item.ItemStack;
+import net.minecraftforge.items.IItemHandler;
+import net.minecraftforge.items.IItemHandlerModifiable;
+import net.minecraftforge.items.ItemStackHandler;
+import org.jetbrains.annotations.NotNull;
+
+import java.util.function.Predicate;
+
+public record ExtractLockItemStackHandlerWrapper(ItemStackHandler source, Predicate<Integer> shouldLock) implements IItemHandler, IItemHandlerModifiable {
+
+    @Override
+    public void setStackInSlot(int slot, @NotNull ItemStack stack) {
+        source.setStackInSlot(slot, stack);
+    }
+
+    @Override
+    public int getSlots() {
+        return source.getSlots();
+    }
+
+    @NotNull
+    @Override
+    public ItemStack getStackInSlot(int slot) {
+        return source.getStackInSlot(slot);
+    }
+
+    @NotNull
+    @Override
+    public ItemStack insertItem(int slot, @NotNull ItemStack stack, boolean simulate) {
+        return source.insertItem(slot, stack, simulate);
+    }
+
+    @NotNull
+    @Override
+    public ItemStack extractItem(int slot, int amount, boolean simulate) {
+        if (this.shouldLock.test(slot)) {
+            return ItemStack.EMPTY;
+        }
+        return source.extractItem(slot, amount, simulate);
+    }
+
+    @Override
+    public int getSlotLimit(int slot) {
+        return source.getSlotLimit(slot);
+    }
+
+    @Override
+    public boolean isItemValid(int slot, @NotNull ItemStack stack) {
+        return source.isItemValid(slot, stack);
+    }
+}


### PR DESCRIPTION
The problem still exists, the input slot of hydroponics (growth chamber) and garden (hydroponics garden) will still get extracted by other block like pipes or item ducts, so i made a utility class to prevent it get extracted from capability interface